### PR TITLE
feat: リリースノート自動作成ワークフローの追加

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: read
 
     steps:
       - name: Checkout
@@ -85,13 +86,59 @@ jobs:
             git push origin "$VERSION"
           fi
 
-      # GitHub Release を作成（PR タイトルから変更履歴を自動生成）
+      # 前回タグ以降に develop にマージされた PR を収集してリリースノートを生成
+      - name: リリースノートを生成
+        id: notes
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+
+          # 前回のタグを取得（現在のタグを除く直近のタグ）
+          PREV_TAG=$(git tag --sort=-version:refname \
+            | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+            | grep -v "^${VERSION}$" \
+            | head -n 1)
+
+          # 前回タグのマージ日時を基準に develop へのマージ済み PR を取得
+          if [ -n "$PREV_TAG" ]; then
+            SINCE=$(git log -1 --format="%Y-%m-%d" "$PREV_TAG")
+            PRS=$(gh pr list \
+              --repo "${{ github.repository }}" \
+              --base develop \
+              --state merged \
+              --search "merged:>${SINCE}" \
+              --limit 100 \
+              --json number,title \
+              --jq '[.[] | "- " + .title + " (#" + (.number | tostring) + ")"] | reverse | .[]')
+          else
+            PRS=$(gh pr list \
+              --repo "${{ github.repository }}" \
+              --base develop \
+              --state merged \
+              --limit 100 \
+              --json number,title \
+              --jq '[.[] | "- " + .title + " (#" + (.number | tostring) + ")"] | reverse | .[]')
+          fi
+
+          {
+            echo "body<<NOTES_EOF"
+            echo "## What's Changed"
+            if [ -n "$PRS" ]; then
+              echo "$PRS"
+            else
+              echo "- No changes"
+            fi
+            echo "NOTES_EOF"
+          } >> $GITHUB_OUTPUT
+
+      # GitHub Release を作成
       - name: GitHub Release を作成
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.version.outputs.version }}
           name: Release ${{ steps.version.outputs.version }}
-          generate_release_notes: true
+          body: ${{ steps.notes.outputs.body }}
 
   # develop に main を同期（squash merge による diverge を解消）
   sync-develop:


### PR DESCRIPTION
- .github/workflows/release.yml を新規追加
  - main への push（Release vX.Y.Z）でタグ・GitHub Release 作成・develop 同期を自動実行
  - workflow_dispatch による手動実行に対応（テスト・緊急リリース用）
  - concurrency でワークフローの並行実行を抑止
  - develop にマージされた PR を収集してリリースノートを自動生成
- docs/01_overview/release_workflow.md を更新
  - ブランチ戦略・バージョンルール・リリース手順・CI/CD 動作を整理

## レビューに関して
 
必ず日本語でレビューすること。
レビューコメントには、以下のプレフィックスをつけること。
 
## コーディングルール
 
このコーディングルールに従っているかをチェックすること。
- anyは使わない
- 変数・フィールド名は camelCase、クラス名は PascalCase、DBカラムは snake_case
 
<!-- for GitHub Copilot review rule -->
 
[必須]: セキュリティ、バグ、重大な設計問題
[推奨]: パフォーマンス改善、可読性向上
[提案]: より良い実装方法の提案
[質問]: 実装意図の確認
[Nits]: 細かな修正（typo、フォーマットなど）
 
<!-- for GitHub Copilot review rule-->