### PR TITLE
fix: リリースノートのPR取得条件を修正（当日マージのPRが除外される問題）

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,12 +102,13 @@ jobs:
 
           # 前回タグのマージ日時を基準に develop へのマージ済み PR を取得
           if [ -n "$PREV_TAG" ]; then
-            SINCE=$(git log -1 --format="%Y-%m-%d" "$PREV_TAG")
+            # ISO 8601形式（タイムゾーン付き）で取得し、当日マージのPRも含める
+            SINCE=$(git log -1 --format="%aI" "$PREV_TAG")
             PRS=$(gh pr list \
               --repo "${{ github.repository }}" \
               --base develop \
               --state merged \
-              --search "merged:>${SINCE}" \
+              --search "merged:>=${SINCE}" \
               --limit 100 \
               --json number,title \
               --jq '[.[] | "- " + .title + " (#" + (.number | tostring) + ")"] | reverse | .[]')


### PR DESCRIPTION
- SINCE のフォーマットを日付のみ (%Y-%m-%d) から ISO 8601 タイムスタンプ (%aI) に変更
- merged:> を merged:>= に変更し、前タグ当日にマージされた PR も含めるよう修正

## レビューに関して
 
必ず日本語でレビューすること。
レビューコメントには、以下のプレフィックスをつけること。
 
## コーディングルール
 
このコーディングルールに従っているかをチェックすること。
- anyは使わない
- 変数・フィールド名は camelCase、クラス名は PascalCase、DBカラムは snake_case
 
<!-- for GitHub Copilot review rule -->
 
[必須]: セキュリティ、バグ、重大な設計問題
[推奨]: パフォーマンス改善、可読性向上
[提案]: より良い実装方法の提案
[質問]: 実装意図の確認
[Nits]: 細かな修正（typo、フォーマットなど）
 
<!-- for GitHub Copilot review rule-->