### PR TITLE
fix: httpclient5のバージョンをhttpcore5互換の5.3.1に修正

### DIFF
--- a/apps/back/build.gradle
+++ b/apps/back/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     annotationProcessor 'org.seasar.doma:doma-processor:3.14.0'
 
     implementation 'com.sendgrid:sendgrid-java:4.10.3'
-    implementation 'org.apache.httpcomponents.client5:httpclient5:5.6.1'
+    implementation 'org.apache.httpcomponents.client5:httpclient5:5.3.1'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.3'
 
     implementation 'com.github.ben-manes.caffeine:caffeine'


### PR DESCRIPTION
httpclient5:5.6.1はhttpcore5:5.4以降で追加されたIOFunctionクラスを使用するが、 Spring Boot 4.0.6のBOMがhttpcore5:5.3.6に固定するため、
経路探索API呼び出し時にNoClassDefFoundErrorが発生していた。
httpclient5を5.3.1（httpcore5:5.3.xと互換性あり）にダウングレードして修正。

## レビューに関して
 
必ず日本語でレビューすること。
レビューコメントには、以下のプレフィックスをつけること。
 
## コーディングルール
 
このコーディングルールに従っているかをチェックすること。
- anyは使わない
- 変数・フィールド名は camelCase、クラス名は PascalCase、DBカラムは snake_case
 
<!-- for GitHub Copilot review rule -->
 
[必須]: セキュリティ、バグ、重大な設計問題
[推奨]: パフォーマンス改善、可読性向上
[提案]: より良い実装方法の提案
[質問]: 実装意図の確認
[Nits]: 細かな修正（typo、フォーマットなど）
 
<!-- for GitHub Copilot review rule-->