### PR TITLE
refactor: AdminInitializerの環境変数参照をSpringプロパティに変更

### DIFF
--- a/apps/back/src/main/java/io/github/taichi0373/kumamoto_henno_map/runner/AdminInitializer.java
+++ b/apps/back/src/main/java/io/github/taichi0373/kumamoto_henno_map/runner/AdminInitializer.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Component;
@@ -15,7 +16,7 @@ import io.github.taichi0373.kumamoto_henno_map.repository.entity.UsersEntity;
 /**
  * アプリ起動時に管理者ユーザーを初期化するランナー。
  * <p>
- * 環境変数 {@code ADMIN_USERNAME} / {@code ADMIN_PASSWORD} / {@code ADMIN_EMAIL} が
+ * プロパティ {@code admin.username} / {@code admin.password} / {@code admin.email} が
  * すべて設定されており、かつ同名ユーザーが存在しない場合のみ管理者ユーザーを作成する。
  * </p>
  */
@@ -27,6 +28,18 @@ public class AdminInitializer implements CommandLineRunner {
     private final UsersDao usersDao;
     private final BCryptPasswordEncoder passwordEncoder;
 
+    /** 管理者ユーザー名 */
+    @Value("${admin.username:}")
+    private String username;
+
+    /** 管理者パスワード */
+    @Value("${admin.password:}")
+    private String password;
+
+    /** 管理者メールアドレス */
+    @Value("${admin.email:}")
+    private String email;
+
     /** コンストラクタインジェクション */
     public AdminInitializer(UsersDao usersDao, BCryptPasswordEncoder passwordEncoder) {
         this.usersDao = usersDao;
@@ -35,12 +48,8 @@ public class AdminInitializer implements CommandLineRunner {
 
     @Override
     public void run(String... args) {
-        String username = System.getenv("ADMIN_USERNAME");
-        String password = System.getenv("ADMIN_PASSWORD");
-        String email    = System.getenv("ADMIN_EMAIL");
-
-        if (username == null || password == null || email == null) {
-            log.info("管理者初期化スキップ: 環境変数 ADMIN_USERNAME / ADMIN_PASSWORD / ADMIN_EMAIL が未設定");
+        if (username.isEmpty() || password.isEmpty() || email.isEmpty()) {
+            log.info("管理者初期化スキップ: admin.username / admin.password / admin.email が未設定");
             return;
         }
 

--- a/apps/back/src/main/resources/application-dev.properties
+++ b/apps/back/src/main/resources/application-dev.properties
@@ -29,6 +29,11 @@ sendgrid.api-key=${SENDGRID_API_KEY:dummy-key-for-dev}
 sendgrid.sandbox=${SENDGRID_SANDBOX:true}
 app.mail.from=${MAIL_FROM:noreply@example.com}
 
+# ===== 管理者初期化（開発環境デフォルト） =====
+admin.username=${ADMIN_USERNAME:admin}
+admin.password=${ADMIN_PASSWORD:admin}
+admin.email=${ADMIN_EMAIL:admin@example.com}
+
 # ===== ロギング =====
 logging.level.io.github.taichi0373.kumamoto_henno_map=DEBUG
 logging.level.org.springframework.web=DEBUG

--- a/apps/back/src/main/resources/application.properties
+++ b/apps/back/src/main/resources/application.properties
@@ -54,6 +54,11 @@ app.password-reset.base-url=${FRONTEND_BASE_URL:http://localhost:3000}
 # ===== OTP 設定 =====
 otp.api.url=${OTP_API_URL:http://localhost:8080/otp/routers/default/plan}
 
+# ===== 管理者初期化設定 =====
+admin.username=${ADMIN_USERNAME:}
+admin.password=${ADMIN_PASSWORD:}
+admin.email=${ADMIN_EMAIL:}
+
 # ===== Slack Webhook 設定 =====
 slack.webhook.url=${SLACK_WEBHOOK_URL:}
 


### PR DESCRIPTION
System.getenv()から@Valueアノテーションに変更し、
application.propertiesで管理者設定を管理できるようにした。
開発環境(dev)ではデフォルト値を設定し、環境変数なしで管理者が自動作成される。
本番環境では既存の環境変数ADMIN_USERNAME等がそのまま引き継がれる。

## レビューに関して
 
必ず日本語でレビューすること。
レビューコメントには、以下のプレフィックスをつけること。
 
## コーディングルール
 
このコーディングルールに従っているかをチェックすること。
- anyは使わない
- 変数・フィールド名は camelCase、クラス名は PascalCase、DBカラムは snake_case
 
<!-- for GitHub Copilot review rule -->
 
[必須]: セキュリティ、バグ、重大な設計問題
[推奨]: パフォーマンス改善、可読性向上
[提案]: より良い実装方法の提案
[質問]: 実装意図の確認
[Nits]: 細かな修正（typo、フォーマットなど）
 
<!-- for GitHub Copilot review rule-->