### PR TITLE
ci: PRのCIチェック強化とDependabot自動マージを追加

### DIFF
--- a/.github/workflows/build-backend.yml
+++ b/.github/workflows/build-backend.yml
@@ -20,7 +20,7 @@ on:
         description: 'Javaバージョン'
         type: string
         default: '21'
-  
+
 env:
   TZ: Asia/Tokyo
   BACKEND_DIR: ${{ inputs.backend-dir }}
@@ -33,6 +33,22 @@ jobs:
     timeout-minutes: ${{ inputs.timeout-minutes }}
     # Github-hosted runner を使用
     runs-on: ubuntu-latest
+
+    # テスト用PostgreSQLサービスコンテナ
+    services:
+      postgres:
+        image: postgres:18
+        env:
+          POSTGRES_DB: kumamoto_henno_map_test
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
 
     env:
       GITHUB_USERNAME: ${{ github.actor }}
@@ -67,6 +83,34 @@ jobs:
       # ビルド
       - name: Compile Java
         run: ./gradlew compileJava
+
+      # テスト用DBスキーマ構築（DDL）
+      - name: Set up test database schema
+        run: |
+          export PGPASSWORD=postgres
+          for f in $(ls ../../config/database/DDL/TABLE/*.SQL | sort); do
+            echo "Running DDL: $f"
+            psql -h localhost -U postgres -d kumamoto_henno_map_test -f "$f"
+          done
+
+      # テスト用データ投入（DML）
+      - name: Load test data
+        run: |
+          export PGPASSWORD=postgres
+          for f in $(ls ../../config/database/DML/TABLE/*.SQL | sort); do
+            echo "Running DML: $f"
+            psql -h localhost -U postgres -d kumamoto_henno_map_test -f "$f"
+          done
+
+      # ユニットテスト実行
+      - name: Run tests
+        run: ./gradlew test
+        env:
+          DB_HOST: localhost
+          DB_PORT: 5432
+          DB_NAME: kumamoto_henno_map_test
+          DB_USERNAME: postgres
+          DB_PASSWORD: postgres
 
       # Javadoc 生成
       - name: Generate Javadoc

--- a/.github/workflows/build-backend.yml
+++ b/.github/workflows/build-backend.yml
@@ -88,19 +88,19 @@ jobs:
       - name: Set up test database schema
         run: |
           export PGPASSWORD=postgres
-          for f in $(ls ../../config/database/DDL/TABLE/*.SQL | sort); do
+          while IFS= read -r f; do
             echo "Running DDL: $f"
             psql -h localhost -U postgres -d kumamoto_henno_map_test -f "$f"
-          done
+          done < <(find ../../config/database/DDL/TABLE -maxdepth 1 -iname "*.sql" | sort)
 
       # テスト用データ投入（DML）
       - name: Load test data
         run: |
           export PGPASSWORD=postgres
-          for f in $(ls ../../config/database/DML/TABLE/*.SQL | sort); do
+          while IFS= read -r f; do
             echo "Running DML: $f"
             psql -h localhost -U postgres -d kumamoto_henno_map_test -f "$f"
-          done
+          done < <(find ../../config/database/DML/TABLE -maxdepth 1 -iname "*.sql" | sort)
 
       # ユニットテスト実行
       - name: Run tests

--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -76,7 +76,7 @@ jobs:
 
       # ユニットテスト
       - name: Unit tests
-        run: npm test -- --ci --passWithNoTests
+        run: npm run test:ci
 
       # # TSDoc 生成
       # - name: Generate TSDoc

--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -7,7 +7,7 @@ on:
       timeout-minutes:
         description: 'タイムアウト（分）'
         type: number
-        default: 10
+        default: 20
 
       frontend-dir:
         description: 'フロントエンドディレクトリ'
@@ -30,7 +30,7 @@ env:
 
 # jobs: 動作内容
 jobs:
-  # フロントエンドのビルド処理（tsdoc, Storybook）
+  # フロントエンドのビルド処理
   frontend-build:
     name: Frontend Build
     # Github-hosted runner を使用
@@ -66,10 +66,22 @@ jobs:
       - name: Install dependencies
         run: ${{ inputs.npm-install-command }}
 
+      # ESLint
+      - name: Lint
+        run: npm run lint
+
+      # プロダクションビルド（TypeScript型チェック含む）
+      - name: Build
+        run: npm run build
+
+      # ユニットテスト
+      - name: Unit tests
+        run: npm test -- --ci --passWithNoTests
+
       # # TSDoc 生成
       # - name: Generate TSDoc
       #   run: npm run typedoc
-
+      #
       # - name: Upload TSDoc
       #   uses: actions/upload-artifact@v7
       #   with:

--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -36,6 +36,8 @@ jobs:
     # Github-hosted runner を使用
     runs-on: ubuntu-latest
     timeout-minutes: ${{ inputs.timeout-minutes }}
+    permissions:
+      contents: read
 
     env:
       GITHUB_USERNAME: ${{ github.actor }}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -4,10 +4,12 @@ on:
   pull_request_target:
     types: [opened, synchronize, reopened]
 
-# Dependabot PRへの書き込み権限
-permissions:
-  pull-requests: write
-  contents: write
+# Dependabotが作成したPRのみに権限を付与
+permissions: {}
+
+concurrency:
+  group: dependabot-auto-merge-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   auto-merge:
@@ -15,6 +17,9 @@ jobs:
     runs-on: ubuntu-latest
     # Dependabotが作成したPRのみ対象
     if: github.actor == 'dependabot[bot]'
+    permissions:
+      pull-requests: write
+      contents: write
     steps:
       - name: Enable auto-merge
         run: gh pr merge --auto --squash "$PR_URL"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,23 @@
+name: Dependabot auto-merge
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+# Dependabot PRへの書き込み権限
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  auto-merge:
+    name: Enable auto-merge for Dependabot PRs
+    runs-on: ubuntu-latest
+    # Dependabotが作成したPRのみ対象
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Enable auto-merge
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/apps/front/package.json
+++ b/apps/front/package.json
@@ -12,7 +12,8 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "test:e2e": "playwright test",
-    "test:e2e:ui": "playwright test --ui"
+    "test:e2e:ui": "playwright test --ui",
+    "test:ci": "jest --ci --passWithNoTests"
   },
   "dependencies": {
     "@primevue/themes": "^4.5.4",
@@ -72,7 +73,9 @@
     ],
     "overrides": [
       {
-        "files": ["*.ts"],
+        "files": [
+          "*.ts"
+        ],
         "parser": "@typescript-eslint/parser"
       }
     ],


### PR DESCRIPTION
## 概要

- PRのたびにLint・ビルド・テストを自動実行するCIチェックを強化
- DependabotのPRはCIが全チェックをパスしたら自動マージされる仕組みを追加

## 変更内容

- `.github/workflows/build-frontend.yml`: ESLint・プロダクションビルド・Jestテスト（`npm run test:ci`）を追加。タイムアウトを20分に変更
- `.github/workflows/build-backend.yml`: PostgreSQL 18サービスコンテナ・DDL/DML実行・`./gradlew test` を追加
- `.github/workflows/dependabot-auto-merge.yml`: 新規作成。DependabotのPRでCIパス後に自動squash mergeを有効化
- `apps/front/package.json`: CI専用テストスクリプト `test:ci` を追加

## マージ後の手動設定（必須）

Branch Protection Rulesの設定が必要です。Settings > Branches から `develop` と `main` に以下を設定してください:

1. **Require status checks to pass before merging** を有効化
2. 必須チェックに `Frontend Build` と `Backend Build` を追加
3. **Allow auto-merge** を有効化（Dependabot自動マージに必要）

## テスト結果

- フロントエンドユニットテスト: 174件全パス（`npm run test:ci`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)