### PR TITLE
fix: Spring Boot 4.1アップグレードに伴うテストコードの修正

### DIFF
--- a/apps/back/src/test/java/io/github/taichi0373/kumamoto_henno_map/config/AdminBenefitCrudTest.java
+++ b/apps/back/src/test/java/io/github/taichi0373/kumamoto_henno_map/config/AdminBenefitCrudTest.java
@@ -2,20 +2,32 @@ package io.github.taichi0373.kumamoto_henno_map.config;
 
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doThrow;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 
 import io.github.taichi0373.kumamoto_henno_map.controller.admin.AdminBenefitController;
 import io.github.taichi0373.kumamoto_henno_map.service.AuthService;
+import io.github.taichi0373.kumamoto_henno_map.service.admin.GeocodingService;
 import io.github.taichi0373.kumamoto_henno_map.service.admin.AdminBenefitService;
 import io.github.taichi0373.kumamoto_henno_map.util.JwtUtil;
 
@@ -26,21 +38,47 @@ import io.github.taichi0373.kumamoto_henno_map.util.JwtUtil;
  * および依存レコードあり DELETE の 409 を検証する。
  * </p>
  */
-@WebMvcTest(AdminBenefitController.class)
-@Import(SecurityConfig.class)
+@ExtendWith(SpringExtension.class)
+@WebAppConfiguration
+@ContextConfiguration(classes = AdminBenefitCrudTest.Config.class)
+@TestPropertySource(properties = {
+    "cors.allowed-origins=http://localhost:3000",
+    "cors.allowed-methods=GET,POST,PUT,DELETE,OPTIONS",
+    "cors.allowed-headers=*",
+    "cors.allow-credentials=true"
+})
 class AdminBenefitCrudTest {
 
+    /** テスト用最小WebMVC設定 */
+    @Configuration
+    @EnableWebMvc
+    @Import({SecurityConfig.class, CorsConfig.class, AdminBenefitController.class})
+    static class Config {
+    }
+
     @Autowired
+    private WebApplicationContext context;
+
     private MockMvc mockMvc;
 
-    @MockBean
+    @MockitoBean
     private JwtUtil jwtUtil;
 
-    @MockBean
+    @MockitoBean
     private AuthService authService;
 
-    @MockBean
+    @MockitoBean
     private AdminBenefitService adminBenefitService;
+
+    @MockitoBean
+    private GeocodingService geocodingService;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.webAppContextSetup(context)
+                .apply(springSecurity())
+                .build();
+    }
 
     /**
      * ROLE_ADMIN で GET /admin/benefits にアクセスすると 200 OK が返ることを確認する
@@ -48,8 +86,7 @@ class AdminBenefitCrudTest {
     @Test
     @WithMockUser(roles = "ADMIN")
     void 管理者ユーザーが特典一覧を取得すると200が返る() throws Exception {
-        mockMvc.perform(
-                org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get("/admin/benefits"))
+        mockMvc.perform(get("/admin/benefits"))
                 .andExpect(status().isOk());
     }
 
@@ -59,8 +96,7 @@ class AdminBenefitCrudTest {
     @Test
     @WithMockUser(roles = "USER")
     void 一般ユーザーが特典一覧にアクセスすると403が返る() throws Exception {
-        mockMvc.perform(
-                org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get("/admin/benefits"))
+        mockMvc.perform(get("/admin/benefits"))
                 .andExpect(status().isForbidden())
                 .andExpect(jsonPath("$.success").value(false));
     }
@@ -70,8 +106,7 @@ class AdminBenefitCrudTest {
      */
     @Test
     void 未認証ユーザーが特典一覧にアクセスすると401が返る() throws Exception {
-        mockMvc.perform(
-                org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get("/admin/benefits"))
+        mockMvc.perform(get("/admin/benefits"))
                 .andExpect(status().isUnauthorized());
     }
 

--- a/apps/back/src/test/java/io/github/taichi0373/kumamoto_henno_map/config/AdminSecurityTest.java
+++ b/apps/back/src/test/java/io/github/taichi0373/kumamoto_henno_map/config/AdminSecurityTest.java
@@ -1,16 +1,26 @@
 package io.github.taichi0373.kumamoto_henno_map.config;
 
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 
 import io.github.taichi0373.kumamoto_henno_map.service.AuthService;
 import io.github.taichi0373.kumamoto_henno_map.util.JwtUtil;
@@ -22,18 +32,41 @@ import io.github.taichi0373.kumamoto_henno_map.util.JwtUtil;
  * レスポンスが返ることを検証する。
  * </p>
  */
-@WebMvcTest(AdminTestController.class)
-@Import(SecurityConfig.class)
+@ExtendWith(SpringExtension.class)
+@WebAppConfiguration
+@ContextConfiguration(classes = AdminSecurityTest.Config.class)
+@TestPropertySource(properties = {
+    "cors.allowed-origins=http://localhost:3000",
+    "cors.allowed-methods=GET,POST,PUT,DELETE,OPTIONS",
+    "cors.allowed-headers=*",
+    "cors.allow-credentials=true"
+})
 class AdminSecurityTest {
 
+    /** テスト用最小WebMVC設定 */
+    @Configuration
+    @EnableWebMvc
+    @Import({SecurityConfig.class, CorsConfig.class, AdminTestController.class})
+    static class Config {
+    }
+
     @Autowired
+    private WebApplicationContext context;
+
     private MockMvc mockMvc;
 
-    @MockBean
+    @MockitoBean
     private JwtUtil jwtUtil;
 
-    @MockBean
+    @MockitoBean
     private AuthService authService;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.webAppContextSetup(context)
+                .apply(springSecurity())
+                .build();
+    }
 
     /**
      * ROLE_USER が /admin/benefits にアクセスした場合に

--- a/apps/back/src/test/java/io/github/taichi0373/kumamoto_henno_map/config/AdminUsersCrudTest.java
+++ b/apps/back/src/test/java/io/github/taichi0373/kumamoto_henno_map/config/AdminUsersCrudTest.java
@@ -3,18 +3,28 @@ package io.github.taichi0373.kumamoto_henno_map.config;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 
 import io.github.taichi0373.kumamoto_henno_map.controller.admin.AdminUsersController;
 import io.github.taichi0373.kumamoto_henno_map.dto.admin.AdminUserResponseDto;
@@ -29,21 +39,44 @@ import io.github.taichi0373.kumamoto_henno_map.util.JwtUtil;
  * PUT /admin/users/{userId} のレスポンスに passwordHash が含まれないことを検証する。
  * </p>
  */
-@WebMvcTest(AdminUsersController.class)
-@Import(SecurityConfig.class)
+@ExtendWith(SpringExtension.class)
+@WebAppConfiguration
+@ContextConfiguration(classes = AdminUsersCrudTest.Config.class)
+@TestPropertySource(properties = {
+    "cors.allowed-origins=http://localhost:3000",
+    "cors.allowed-methods=GET,POST,PUT,DELETE,OPTIONS",
+    "cors.allowed-headers=*",
+    "cors.allow-credentials=true"
+})
 class AdminUsersCrudTest {
 
+    /** テスト用最小WebMVC設定 */
+    @Configuration
+    @EnableWebMvc
+    @Import({SecurityConfig.class, CorsConfig.class, AdminUsersController.class})
+    static class Config {
+    }
+
     @Autowired
+    private WebApplicationContext context;
+
     private MockMvc mockMvc;
 
-    @MockBean
+    @MockitoBean
     private JwtUtil jwtUtil;
 
-    @MockBean
+    @MockitoBean
     private AuthService authService;
 
-    @MockBean
+    @MockitoBean
     private AdminUsersService adminUsersService;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.webAppContextSetup(context)
+                .apply(springSecurity())
+                .build();
+    }
 
     /**
      * PUT /admin/users/{userId} のレスポンスに passwordHash フィールドが含まれないことを確認する


### PR DESCRIPTION
## 概要

Spring Boot `4.0.6 → 4.1.0` バンプ（#269）により、テストコードがビルド不可になっていた問題を修正する。

## 変更内容

### 問題

Spring Boot 4.1 では以下の API が削除された:
- `org.springframework.boot.test.mock.mockito.MockBean` (3.4 で非推奨 → 4.x で削除)
- `org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest` (4.1 の `spring-boot-test-autoconfigure` から削除)

### 修正

| 対象ファイル | 変更内容 |
|---|---|
| `AdminSecurityTest.java` | `@MockBean` → `@MockitoBean`、`@WebMvcTest` → `@ExtendWith` + `@WebAppConfiguration` + `@ContextConfiguration` |
| `AdminBenefitCrudTest.java` | 同上 + `GeocodingService` の `@MockitoBean` を追加 |
| `AdminUsersCrudTest.java` | `@MockBean` → `@MockitoBean`、`@WebMvcTest` → `@ExtendWith` + `@WebAppConfiguration` + `@ContextConfiguration` |

### 移行後のテスト構成

`@WebMvcTest` の代替として、最小限の Spring コンテキストを手動で構成:

```java
@ExtendWith(SpringExtension.class)
@WebAppConfiguration
@ContextConfiguration(classes = XxxTest.Config.class)
class XxxTest {
    @Configuration
    @EnableWebMvc
    @Import({SecurityConfig.class, CorsConfig.class, XxxController.class})
    static class Config {}
    // ...
}
```

## テスト結果

`./gradlew build` が成功することを確認済み（全テスト通過）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)