### PR TITLE
fix: ESLint v10対応のフラットコンフィグへ移行

### DIFF
--- a/apps/front/eslint.config.mjs
+++ b/apps/front/eslint.config.mjs
@@ -1,0 +1,70 @@
+import eslint from '@eslint/js';
+import pluginVue from 'eslint-plugin-vue';
+import tsParser from '@typescript-eslint/parser';
+import tsPlugin from '@typescript-eslint/eslint-plugin';
+import globals from 'globals';
+
+/** 共通グローバル変数 */
+const commonGlobals = {
+  ...globals.node,
+  ...globals.browser,
+  ...globals.es2015,
+  ...globals.jest,
+};
+
+/** 共通TypeScriptルール */
+const commonTsRules = {
+  'no-unused-vars': 'off',
+  '@typescript-eslint/no-unused-vars': 'warn',
+  '@typescript-eslint/no-explicit-any': 'off',
+};
+
+export default [
+  // 全ファイル共通: グローバル変数設定
+  {
+    languageOptions: {
+      globals: commonGlobals,
+    },
+  },
+
+  // eslint 推奨ルール
+  eslint.configs.recommended,
+
+  // Vue 推奨ルール（essential）
+  ...pluginVue.configs['flat/essential'],
+
+  // Vue ファイル: TypeScriptパーサーを設定
+  {
+    files: ['**/*.vue'],
+    languageOptions: {
+      parserOptions: {
+        parser: tsParser,
+        ecmaVersion: 2020,
+        sourceType: 'module',
+      },
+    },
+    plugins: {
+      '@typescript-eslint': tsPlugin,
+    },
+    rules: {
+      'vue/multi-word-component-names': 'off',
+      ...commonTsRules,
+    },
+  },
+
+  // TypeScript ファイル
+  {
+    files: ['**/*.ts', '**/*.tsx'],
+    languageOptions: {
+      parser: tsParser,
+      parserOptions: {
+        ecmaVersion: 2020,
+        sourceType: 'module',
+      },
+    },
+    plugins: {
+      '@typescript-eslint': tsPlugin,
+    },
+    rules: commonTsRules,
+  },
+];

--- a/apps/front/package.json
+++ b/apps/front/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "serve": "vite",
     "build": "vite build",
-    "lint": "eslint src --ext .ts,.tsx,.vue",
+    "lint": "eslint src",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "test": "jest",
@@ -50,41 +50,6 @@
   },
   "optionalDependencies": {
     "@rollup/rollup-linux-x64-gnu": "4.62.2"
-  },
-  "eslintConfig": {
-    "root": true,
-    "env": {
-      "node": true,
-      "browser": true,
-      "es6": true,
-      "jest": true
-    },
-    "extends": [
-      "plugin:vue/essential",
-      "eslint:recommended"
-    ],
-    "parserOptions": {
-      "parser": "@typescript-eslint/parser",
-      "ecmaVersion": 2020,
-      "sourceType": "module"
-    },
-    "plugins": [
-      "@typescript-eslint"
-    ],
-    "overrides": [
-      {
-        "files": [
-          "*.ts"
-        ],
-        "parser": "@typescript-eslint/parser"
-      }
-    ],
-    "rules": {
-      "vue/multi-word-component-names": "off",
-      "no-unused-vars": "off",
-      "@typescript-eslint/no-unused-vars": "warn",
-      "@typescript-eslint/no-explicit-any": "off"
-    }
   },
   "browserslist": [
     "> 1%",


### PR DESCRIPTION
## 概要

ESLint が `^10.4.1` にバンプされた際、設定ファイルの形式が旧形式（`package.json#eslintConfig`）のままだったため、GitHub Actions の lint ステップが失敗していた問題を修正する。

## 原因

ESLint v9+ からデフォルトの設定ファイルが `eslint.config.(js|mjs|cjs)` に変更された。また `--ext` フラグも v9+ で廃止されている。

## 変更内容

| ファイル | 変更 |
|---|---|
| `apps/front/eslint.config.mjs` | 新規作成（フラットコンフィグ形式） |
| `apps/front/package.json` | `eslintConfig` セクション削除、lint スクリプトから `--ext` フラグ削除 |

### 設定の対応表

| 旧形式 | 新形式 |
|---|---|
| `"extends": ["eslint:recommended"]` | `eslint.configs.recommended` |
| `"extends": ["plugin:vue/essential"]` | `pluginVue.configs['flat/essential']` |
| `"plugins": ["@typescript-eslint"]` | `plugins: { '@typescript-eslint': tsPlugin }` |
| `"env": { "browser": true, ... }` | `globals: { ...globals.browser, ... }` |

## 確認済み

`npm run lint` がエラー 0 件で通過することを確認（警告 9 件は既存コードの未使用変数）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)