### PR TITLE
fix: リリースノートからDependabotのPRを除外するフィルターを修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,7 +114,7 @@ jobs:
               --search "merged:>=${SINCE}" \
               --limit 100 \
               --json number,title,author \
-              --jq '[.[] | select(.author.login != "dependabot[bot]") | "- " + .title + " (#" + (.number | tostring) + ")"] | reverse | .[]')
+              --jq '[.[] | select(.author.login != "app/dependabot" and .author.login != "dependabot[bot]") | "- " + .title + " (#" + (.number | tostring) + ")"] | reverse | .[]')
           else
             PRS=$(gh pr list \
               --repo "${{ github.repository }}" \
@@ -122,7 +122,7 @@ jobs:
               --state merged \
               --limit 100 \
               --json number,title,author \
-              --jq '[.[] | select(.author.login != "dependabot[bot]") | "- " + .title + " (#" + (.number | tostring) + ")"] | reverse | .[]')
+              --jq '[.[] | select(.author.login != "app/dependabot" and .author.login != "dependabot[bot]") | "- " + .title + " (#" + (.number | tostring) + ")"] | reverse | .[]')
           fi
 
           {


### PR DESCRIPTION
## 概要

issue #249 の修正。リリースノート生成時にDependabotのPRが除外されない問題を修正。

## 原因

`release.yml` のjqフィルターが `"dependabot[bot]"` でフィルタリングしていたが、`gh pr list --json author` が返す実際のlogin値は **`"app/dependabot"`** だった。

```json
// 実際の返り値
{"author": {"is_bot": true, "login": "app/dependabot"}}
```

`"app/dependabot" != "dependabot[bot]"` は `true` となるため除外されずリリースノートに含まれていた。

## 修正内容

`release.yml` の2箇所（前回タグあり・なしの両分岐）を修正。

```jq
// 変更前
select(.author.login != "dependabot[bot]")

// 変更後（両形式に対応）
select(.author.login != "app/dependabot" and .author.login != "dependabot[bot]")
```

## テスト確認

- [ ] 次回リリース時にDependabotのPRがリリースノートに含まれないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)