### PR TITLE
fix: PRワークフローのpathsフィルター削除

### DIFF
--- a/.github/workflows/pull-request-review.yml
+++ b/.github/workflows/pull-request-review.yml
@@ -3,10 +3,6 @@ name: Check on pull request
 on:
   pull_request:
     branches: ["develop", "main"]
-    paths:
-      - 'docs/**'
-      - 'apps/front/**'
-      - 'apps/back/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## 概要

- `pull-request-review.yml` のワークフロートリガーから `paths` フィルターを削除

## 問題

ワークフロートリガーに `paths` フィルターが設定されていたため、`docs/**`・`apps/front/**`・`apps/back/**` 以外のファイルのみ変更したPRでは、ワークフロー全体がスキップされていた。
その結果、Ruleset で必須チェックとして設定している `All Checks Passed` が報告されず、マージ不可となる事象が複数のPRで発生していた。

## 修正内容

`paths` フィルターを削除。各ビルドジョブはすでに `precheck` の差分チェック結果に基づく `if` 条件で制御されているため、不要なビルドは引き続きスキップされる。

## 動作確認

| PRの変更内容 | Frontend Build | Backend Build | Document Build | All Checks Passed |
|---|---|---|---|---|
| `apps/front/**` のみ | 実行 | スキップ | スキップ | 成功 |
| `apps/back/**` のみ | スキップ | 実行 | スキップ | 成功 |
| `.github/workflows/**` のみ | スキップ | スキップ | スキップ | 成功 |
| いずれかのビルドが失敗 | — | — | — | 失敗 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)