### PR TITLE
ci: DependabotのPRにラベルを自動付与

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -21,6 +21,16 @@ jobs:
       pull-requests: write
       contents: write
     steps:
+      - name: リリースノート除外ラベルを付与
+        run: |
+          gh pr edit "$PR_NUMBER" \
+            --add-label "依存関係,リリースノート除外" \
+            --repo "$REPO"
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Enable auto-merge
         run: gh pr merge --auto --squash "$PR_URL"
         env:


### PR DESCRIPTION
## 概要

Dependabotが作成するPRに「依存関係」「リリースノート除外」ラベルを自動付与する。

## 変更内容

- `dependabot-auto-merge.yml` にラベル付与ステップを追加
- auto-label-pr.yml は `github.actor != 'dependabot[bot]'` でスキップされるため、Dependabot専用ワークフロー側で対応

## 付与されるラベル

| ラベル | 理由 |
|--------|------|
| `依存関係` | 依存パッケージの更新PRであることを示す |
| `リリースノート除外` | 依存関係の更新はリリースノートに記載しない |

🤖 Generated with [Claude Code](https://claude.com/claude-code)