### PR TITLE
fix: フロントエンドの未使用変数を削除

### DIFF
--- a/apps/front/src/pages/HomePage.vue
+++ b/apps/front/src/pages/HomePage.vue
@@ -97,7 +97,6 @@
 <script setup lang="ts">
 import 'maplibre-gl/dist/maplibre-gl.css'
 import { ref, computed, watch, onMounted } from 'vue'
-import { useRouter } from 'vue-router'
 import AppRouteGuidance from '@/components/organisms/AppRouteGuidance.vue'
 import AppUsersBenefit from '@/components/organisms/AppUsersBenefit.vue'
 import AppSearchBenefit from '@/components/organisms/AppSearchBenefit.vue'
@@ -125,9 +124,6 @@ import { TypeConvertUtils } from '@/utils/typeConvertUtils'
 import { ToastMessageUtils } from '@/utils/toastMessageUtils'
 import { responseStatusConstant } from '@/utils/responseStatusConstant'
 import { API_RESPONSE_MESSAGE, GEOLOCATION_MESSAGE } from '@/utils/messageConstant'
-
-/** ルーター */
-const router = useRouter()
 
 /** nominatim api url */
 const NOMINATIM_API_URL = 'https://nominatim.openstreetmap.org'
@@ -323,7 +319,7 @@ const handleSearchRoute = async (routeRequest: RouteRequestDto) => {
       addRouteLines([])
       ToastMessageUtils.error(API_RESPONSE_MESSAGE.ROUTE_SEARCH_FAILED)
     }
-  } catch (error) {
+  } catch {
     addRouteLines([])
     ToastMessageUtils.error(API_RESPONSE_MESSAGE.ROUTE_SEARCH_FAILED)
   } finally {

--- a/apps/front/src/pages/admin/AdminAgencyPage.vue
+++ b/apps/front/src/pages/admin/AdminAgencyPage.vue
@@ -399,8 +399,7 @@ const importCSV = async () => {
     )
     closeImportDialog()
     await fetchItems(page.value)
-  } catch (error: unknown) {
-    const msg = (error as { response?: { data?: { message?: string } } })?.response?.data?.message
+  } catch {
     ToastMessageUtils.error('登録に失敗しました')
   } finally {
     isImporting.value = false

--- a/apps/front/src/pages/admin/AdminBenefitCategoryPage.vue
+++ b/apps/front/src/pages/admin/AdminBenefitCategoryPage.vue
@@ -402,8 +402,7 @@ const importCSV = async () => {
     )
     closeImportDialog()
     await fetchItems()
-  } catch (error: unknown) {
-    const msg = (error as { response?: { data?: { message?: string } } })?.response?.data?.message
+  } catch {
     ToastMessageUtils.error('登録に失敗しました')
   } finally {
     isImporting.value = false

--- a/apps/front/src/pages/admin/AdminBenefitEligibilityPage.vue
+++ b/apps/front/src/pages/admin/AdminBenefitEligibilityPage.vue
@@ -390,8 +390,7 @@ const importCSV = async () => {
     ToastMessageUtils.success(`インポート完了: 登録 ${result?.inserted ?? 0} 件`)
     closeImportDialog()
     await fetchItems(page.value)
-  } catch (error: unknown) {
-    const msg = (error as { response?: { data?: { message?: string } } })?.response?.data?.message
+  } catch {
     ToastMessageUtils.error('登録に失敗しました')
   } finally {
     isImporting.value = false

--- a/apps/front/src/pages/admin/AdminBenefitPage.vue
+++ b/apps/front/src/pages/admin/AdminBenefitPage.vue
@@ -462,8 +462,7 @@ const importCSV = async () => {
     )
     closeImportDialog()
     await fetchItems(page.value)
-  } catch (error: unknown) {
-    const msg = (error as { response?: { data?: { message?: string } } })?.response?.data?.message
+  } catch {
     ToastMessageUtils.error('登録に失敗しました')
   } finally {
     isImporting.value = false

--- a/apps/front/src/pages/admin/AdminCommunityBusPage.vue
+++ b/apps/front/src/pages/admin/AdminCommunityBusPage.vue
@@ -406,8 +406,7 @@ const importCSV = async () => {
     )
     closeImportDialog()
     await fetchItems(page.value)
-  } catch (error: unknown) {
-    const msg = (error as { response?: { data?: { message?: string } } })?.response?.data?.message
+  } catch {
     ToastMessageUtils.error('登録に失敗しました')
   } finally {
     isImporting.value = false

--- a/apps/front/src/pages/admin/AdminFareDiscountPage.vue
+++ b/apps/front/src/pages/admin/AdminFareDiscountPage.vue
@@ -409,8 +409,7 @@ const importCSV = async () => {
     )
     closeImportDialog()
     await fetchItems(page.value)
-  } catch (error: unknown) {
-    const msg = (error as { response?: { data?: { message?: string } } })?.response?.data?.message
+  } catch {
     ToastMessageUtils.error('登録に失敗しました')
   } finally {
     isImporting.value = false

--- a/apps/front/src/pages/admin/AdminMunicipalityPage.vue
+++ b/apps/front/src/pages/admin/AdminMunicipalityPage.vue
@@ -370,8 +370,7 @@ const importCSV = async () => {
     )
     closeImportDialog()
     await fetchItems(page.value)
-  } catch (error: unknown) {
-    const msg = (error as { response?: { data?: { message?: string } } })?.response?.data?.message
+  } catch {
     ToastMessageUtils.error('登録に失敗しました')
   } finally {
     isImporting.value = false


### PR DESCRIPTION
## 概要

ESLint で検出された未使用変数の警告（9件）を修正しました。

## 変更内容

- `HomePage.vue`: `useRouter` インポートと `const router = useRouter()` を削除、`catch (error)` → `catch`（オプショナルキャッチバインディング）
- `AdminAgencyPage.vue` 他6ページ: インポート処理のcatchブロックで `const msg` を宣言していたが使用されていなかったため、`catch (error: unknown)` と未使用変数を削除

## 確認事項

- [x] `npm run lint` → 警告 0件
- [x] `npm run build` → ビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)