### PR TITLE
feat: 現在地周辺クイックフィルター機能を追加

### DIFF
--- a/apps/back/src/main/java/io/github/taichi0373/kumamoto_henno_map/dto/BenefitEligibilityDto.java
+++ b/apps/back/src/main/java/io/github/taichi0373/kumamoto_henno_map/dto/BenefitEligibilityDto.java
@@ -54,6 +54,18 @@ public class BenefitEligibilityDto {
     @Schema(description = "カテゴリコード", example = "TR001")
     private String categoryCd;
 
+    /** 現在地緯度（現在地周辺フィルタリング用） */
+    @Schema(description = "現在地緯度", example = "32.789")
+    private Double latitude;
+
+    /** 現在地経度（現在地周辺フィルタリング用） */
+    @Schema(description = "現在地経度", example = "130.741")
+    private Double longitude;
+
+    /** 検索半径（km）。省略時は2km */
+    @Schema(description = "検索半径（km）", example = "2.0")
+    private Double radiusKm;
+
     /** システム共通フィールド */
     @Schema(hidden = true)
     private SystemField systemField;

--- a/apps/back/src/main/java/io/github/taichi0373/kumamoto_henno_map/service/BenefitService.java
+++ b/apps/back/src/main/java/io/github/taichi0373/kumamoto_henno_map/service/BenefitService.java
@@ -55,13 +55,26 @@ public class BenefitService {
      */
     public List<BenefitDetailEntity> searchBenefits(BenefitEligibilityDto request) {
         // 特典適用条件に一致する特典を取得
-        return benefitDetailDao.selectEligible(
+        List<BenefitDetailEntity> results = benefitDetailDao.selectEligible(
             request.getAge(),
             request.getLicenseStatus(),
             request.getMunicipalityCd(),
             request.getKeyword(),
             request.getCategoryCd()
         );
+
+        // 現在地周辺フィルタリング
+        if (request.getLatitude() != null && request.getLongitude() != null) {
+            double radiusKm = (request.getRadiusKm() != null) ? request.getRadiusKm() : 2.0;
+            results = results.stream()
+                .filter(b -> b.getLatitude() != null && b.getLongitude() != null)
+                .filter(b -> isWithinRadius(
+                    b.getLatitude().doubleValue(), b.getLongitude().doubleValue(),
+                    request.getLatitude(), request.getLongitude(), radiusKm))
+                .collect(java.util.stream.Collectors.toList());
+        }
+
+        return results;
     }
 
     /**
@@ -79,6 +92,29 @@ public class BenefitService {
                     return dto;
                 })
                 .toList();
+    }
+
+    /**
+     * 2点間の距離がradiusKm以内かどうかをHaversine公式で判定する
+     *
+     * @param lat1      地点1の緯度
+     * @param lng1      地点1の経度
+     * @param lat2      地点2の緯度
+     * @param lng2      地点2の経度
+     * @param radiusKm  判定半径（km）
+     * @return radiusKm以内であればtrue
+     */
+    private boolean isWithinRadius(double lat1, double lng1,
+                                    double lat2, double lng2,
+                                    double radiusKm) {
+        final double R = 6371.0; // 地球の半径（km）
+        double dLat = Math.toRadians(lat2 - lat1);
+        double dLng = Math.toRadians(lng2 - lng1);
+        double a = Math.sin(dLat / 2) * Math.sin(dLat / 2)
+            + Math.cos(Math.toRadians(lat1)) * Math.cos(Math.toRadians(lat2))
+            * Math.sin(dLng / 2) * Math.sin(dLng / 2);
+        double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+        return R * c <= radiusKm;
     }
 
     /**

--- a/apps/back/src/test/java/io/github/taichi0373/kumamoto_henno_map/service/BenefitServiceNearbyTest.java
+++ b/apps/back/src/test/java/io/github/taichi0373/kumamoto_henno_map/service/BenefitServiceNearbyTest.java
@@ -1,0 +1,100 @@
+package io.github.taichi0373.kumamoto_henno_map.service;
+
+import io.github.taichi0373.kumamoto_henno_map.dto.BenefitEligibilityDto;
+import io.github.taichi0373.kumamoto_henno_map.repository.dao.BenefitCategoryDao;
+import io.github.taichi0373.kumamoto_henno_map.repository.dao.BenefitDetailDao;
+import io.github.taichi0373.kumamoto_henno_map.repository.dao.UsersDao;
+import io.github.taichi0373.kumamoto_henno_map.repository.entity.BenefitDetailEntity;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+/** BenefitService の現在地周辺フィルタリングのテスト */
+@ExtendWith(MockitoExtension.class)
+class BenefitServiceNearbyTest {
+
+    @InjectMocks
+    private BenefitService benefitService;
+
+    @Mock
+    private BenefitDetailDao benefitDetailDao;
+
+    @Mock
+    private BenefitCategoryDao benefitCategoryDao;
+
+    @Mock
+    private UsersDao usersDao;
+
+    /** 熊本市役所の座標（テスト基準点） */
+    private static final double KUMAMOTO_LAT = 32.7897;
+    private static final double KUMAMOTO_LNG = 130.7416;
+
+    private BenefitDetailEntity createBenefitWithCoords(String id, double lat, double lng) {
+        BenefitDetailEntity b = new BenefitDetailEntity();
+        b.setBenefitId(id);
+        b.setLatitude(BigDecimal.valueOf(lat));
+        b.setLongitude(BigDecimal.valueOf(lng));
+        return b;
+    }
+
+    @Test
+    void 現在地指定なしのとき全件返す() {
+        BenefitDetailEntity b1 = createBenefitWithCoords("B001", KUMAMOTO_LAT, KUMAMOTO_LNG);
+        BenefitDetailEntity b2 = createBenefitWithCoords("B002", 33.0, 131.0); // 遠い
+        when(benefitDetailDao.selectEligible(any(), any(), any(), any(), any()))
+            .thenReturn(List.of(b1, b2));
+
+        BenefitEligibilityDto request = new BenefitEligibilityDto();
+        // latitude, longitude を設定しない
+
+        List<BenefitDetailEntity> result = benefitService.searchBenefits(request);
+
+        assertThat(result).hasSize(2);
+    }
+
+    @Test
+    void 現在地指定ありのとき半径2km以内のみ返す() {
+        // 熊本市役所から約0.5km
+        BenefitDetailEntity nearby = createBenefitWithCoords("B001", 32.7930, 130.7416);
+        // 熊本市役所から約30km
+        BenefitDetailEntity far = createBenefitWithCoords("B002", 33.0, 131.0);
+        when(benefitDetailDao.selectEligible(any(), any(), any(), any(), any()))
+            .thenReturn(List.of(nearby, far));
+
+        BenefitEligibilityDto request = new BenefitEligibilityDto();
+        request.setLatitude(KUMAMOTO_LAT);
+        request.setLongitude(KUMAMOTO_LNG);
+        request.setRadiusKm(2.0);
+
+        List<BenefitDetailEntity> result = benefitService.searchBenefits(request);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getBenefitId()).isEqualTo("B001");
+    }
+
+    @Test
+    void 座標がnullの特典は現在地フィルタリング時に除外される() {
+        BenefitDetailEntity noCoords = new BenefitDetailEntity();
+        noCoords.setBenefitId("B003");
+        // latitude, longitude = null
+        when(benefitDetailDao.selectEligible(any(), any(), any(), any(), any()))
+            .thenReturn(List.of(noCoords));
+
+        BenefitEligibilityDto request = new BenefitEligibilityDto();
+        request.setLatitude(KUMAMOTO_LAT);
+        request.setLongitude(KUMAMOTO_LNG);
+
+        List<BenefitDetailEntity> result = benefitService.searchBenefits(request);
+
+        assertThat(result).isEmpty();
+    }
+}

--- a/apps/front/src/components/organisms/AppSearchBenefit.vue
+++ b/apps/front/src/components/organisms/AppSearchBenefit.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="p-2">
-   <form @submit.prevent="searchBenefits(searchBenefit)">
+   <form @submit.prevent="searchBenefits()">
       <div class="form-row-1">
         <div class="form-col form-col--wide">
           <AppLabel :id="'keyword'">フリーワード</AppLabel>
@@ -34,6 +34,15 @@
       <div class="form-btn">
         <AppButton :label="'クリア'" :primary="false" :icon="'pi pi-trash'" @click="clearConditions" />
         <AppButton type="submit" :label="'検索'" :primary="true" :icon="'pi pi-search'" :disabled="isLoading" />
+      </div>
+      <!-- 現在地周辺フィルターボタン -->
+      <div class="form-btn mt-2">
+        <AppButton
+          label="現在地周辺"
+          severity="secondary"
+          icon="pi pi-map-marker"
+          @click="filterByCurrentLocation"
+        />
       </div>
     </form>
   </div>
@@ -279,15 +288,19 @@ const getLicenseStatusName = (code: string) => {
 }
 
 // 特典検索API呼び出し
-const searchBenefits = async (conditions: SearchBenefitDto) => {
+const searchBenefits = async () => {
   isLoading.value = true
   hasSearched.value = true
+  const conditions = searchBenefit.value
   const requestData = {
     age: conditions.age,
     licenseStatus: conditions.licenseStatus,
     municipalityCd: conditions.address,
     keyword: conditions.keyword,
     categoryCd: conditions.categoryCd,
+    latitude: conditions.latitude,
+    longitude: conditions.longitude,
+    radiusKm: conditions.radiusKm,
   }
 
   try {
@@ -313,10 +326,36 @@ const searchBenefits = async (conditions: SearchBenefitDto) => {
 // 条件クリア
 const clearConditions = () => {
   searchBenefit.value = new SearchBenefitDto()
+  searchBenefit.value.latitude = undefined
+  searchBenefit.value.longitude = undefined
+  searchBenefit.value.radiusKm = undefined
   benefitResults.value = []
   hasSearched.value = false
   openCategories.value = new Set()
   emit('clear-benefit-markers')
+}
+
+/**
+ * 現在地を取得して周辺2km以内の特典を検索する
+ */
+const filterByCurrentLocation = () => {
+  if (!navigator.geolocation) {
+    ToastMessageUtils.error('このブラウザはGPS位置情報に対応していません')
+    return
+  }
+  navigator.geolocation.getCurrentPosition(
+    (position) => {
+      searchBenefit.value.latitude = position.coords.latitude
+      searchBenefit.value.longitude = position.coords.longitude
+      searchBenefit.value.radiusKm = 2.0
+      searchBenefits()
+    },
+    () => {
+      ToastMessageUtils.error(
+        '位置情報の取得に失敗しました。ブラウザの設定で位置情報の使用を許可してください'
+      )
+    }
+  )
 }
 
 /** 対象年齢の表示用文言を組み立て */

--- a/apps/front/src/dto/searchBenefitDto.ts
+++ b/apps/front/src/dto/searchBenefitDto.ts
@@ -12,6 +12,12 @@ interface SearchBenefitInterface {
     keyword: string | null;
     /** カテゴリコード */
     categoryCd: string | null;
+    /** 現在地緯度（現在地周辺フィルタリング用） */
+    latitude: number | undefined;
+    /** 現在地経度（現在地周辺フィルタリング用） */
+    longitude: number | undefined;
+    /** 検索半径（km） */
+    radiusKm: number | undefined;
 }
 
 /**
@@ -28,6 +34,12 @@ class SearchBenefitDto {
     keyword: string | null;
     /** カテゴリコード */
     categoryCd: string | null;
+    /** 現在地緯度（現在地周辺フィルタリング用） */
+    latitude: number | undefined;
+    /** 現在地経度（現在地周辺フィルタリング用） */
+    longitude: number | undefined;
+    /** 検索半径（km） */
+    radiusKm: number | undefined;
     /**
      * コンストラクタ
      * @param searchBenefitInterface 特典検索インタフェース
@@ -39,12 +51,18 @@ class SearchBenefitDto {
             this.age = searchBenefitInterface.age != null ? searchBenefitInterface.age : null;
             this.keyword = searchBenefitInterface.keyword != null ? searchBenefitInterface.keyword : null;
             this.categoryCd = searchBenefitInterface.categoryCd != null ? searchBenefitInterface.categoryCd : null;
+            this.latitude = searchBenefitInterface.latitude;
+            this.longitude = searchBenefitInterface.longitude;
+            this.radiusKm = searchBenefitInterface.radiusKm;
         } else {
             this.address = null;
             this.licenseStatus = null;
             this.age = null;
             this.keyword = null;
             this.categoryCd = null;
+            this.latitude = undefined;
+            this.longitude = undefined;
+            this.radiusKm = undefined;
         }
     }
 }


### PR DESCRIPTION
## 概要
- 特典検索タブに「現在地周辺」ボタンを追加
- ボタンクリック → GPS取得 → 半径2km以内の特典を自動検索
- GPS拒否時はトースト通知

## 変更箇所
- `BenefitEligibilityDto`: `latitude`, `longitude`, `radiusKm` フィールドを追加
- `BenefitService.searchBenefits()`: Haversine公式による距離フィルタリングを追加
- `SearchBenefitDto`: `latitude`, `longitude`, `radiusKm` フィールドを追加
- `AppSearchBenefit.vue`: 「現在地周辺」ボタンと位置情報取得ロジックを追加

## テスト
- `BenefitServiceNearbyTest` でユニットテスト追加済み（範囲内/範囲外/座標なし）
- `./gradlew test` 全通過確認済み
- `npm run lint` エラーなし確認済み