### PR TITLE
fix: PrimeVue を v5.0.0 から v4.5.5 にダウングレード

### DIFF
--- a/apps/front/package-lock.json
+++ b/apps/front/package-lock.json
@@ -14,7 +14,7 @@
         "pinia": "^4.0.2",
         "primeflex": "^4.0.0",
         "primeicons": "^8.0.0",
-        "primevue": "^5.0.0",
+        "primevue": "^4.5.5",
         "vue": "^3.5.40",
         "vue-router": "^5.2.0"
       },
@@ -1950,27 +1950,6 @@
         "@tybys/wasm-util": "^0.10.0"
       }
     },
-    "node_modules/@noble/ed25519": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-2.3.0.tgz",
-      "integrity": "sha512-M7dvXL2B92/M7dw9+gzuydL8qn/jiqNHaoR3Q+cb1q1GHV7uwE17WCyFMG+Y+TZb5izcaXk5TdJRrDUxHXL78A==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@noble/hashes": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
-      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/@oxc-parser/binding-android-arm-eabi": {
       "version": "0.127.0",
       "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.127.0.tgz",
@@ -3003,77 +2982,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@primeicons/core": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@primeicons/core/-/core-8.0.0.tgz",
-      "integrity": "sha512-vPif+sXxajXCSL2bmNBP0QYliJONVRgFVpCg9e7hGn7IG18JkMAm4fF5HVld1N4sDATkZQM7jKVxdZ8EK09Giw==",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@primeuix/utils": "^0.8.0"
-      }
-    },
-    "node_modules/@primeicons/core/node_modules/@primeuix/utils": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@primeuix/utils/-/utils-0.8.0.tgz",
-      "integrity": "sha512-dZSMKU2XJ7W7VDLuFMS/o4k+QYw4SYIpqSNhR/jdasMaaXl8eq0Gt7fTzTwwq7hgfmfOsI6V5xtzUUIvybOJ/w==",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "engines": {
-        "node": ">=12.11.0"
-      }
-    },
-    "node_modules/@primeicons/vue": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@primeicons/vue/-/vue-8.0.0.tgz",
-      "integrity": "sha512-sIqk+kZB9Bn0FqODjDAnNvRXY4Ypky2TInY/oIC3aAJOud1A3FoKruMC8IwiRDz1uHzxYnQqWwtFsfZAgC7qXQ==",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@primeicons/core": "8.0.0",
-        "@primeuix/utils": "^0.8.0"
-      },
-      "peerDependencies": {
-        "vue": "^3"
-      }
-    },
-    "node_modules/@primeicons/vue/node_modules/@primeuix/utils": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@primeuix/utils/-/utils-0.8.0.tgz",
-      "integrity": "sha512-dZSMKU2XJ7W7VDLuFMS/o4k+QYw4SYIpqSNhR/jdasMaaXl8eq0Gt7fTzTwwq7hgfmfOsI6V5xtzUUIvybOJ/w==",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "engines": {
-        "node": ">=12.11.0"
-      }
-    },
-    "node_modules/@primeui/license-manager": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@primeui/license-manager/-/license-manager-1.0.0.tgz",
-      "integrity": "sha512-89J7r8cclEqoHVwjOX1adPcB/blFSocpzuYlzmd+6r0gxzg2Vd4jM54TKXt9/qwAT/kOv4vYnHKZ6hcP2GFtfA==",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@noble/ed25519": "2.3.0",
-        "@noble/hashes": "2.2.0"
-      }
-    },
-    "node_modules/@primeuix/motion": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@primeuix/motion/-/motion-1.0.0.tgz",
-      "integrity": "sha512-rqpFRKmUVp9BI3YQKdok0rLUwzYShXzuuxy72Kq74xYRV14eR+4+XrIXOdyVs7j7CYV0ajYowiRpJCrVgdrq6A==",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@primeuix/utils": "^0.8.0"
-      },
-      "engines": {
-        "node": ">=12.11.0"
-      }
-    },
-    "node_modules/@primeuix/motion/node_modules/@primeuix/utils": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@primeuix/utils/-/utils-0.8.0.tgz",
-      "integrity": "sha512-dZSMKU2XJ7W7VDLuFMS/o4k+QYw4SYIpqSNhR/jdasMaaXl8eq0Gt7fTzTwwq7hgfmfOsI6V5xtzUUIvybOJ/w==",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "engines": {
-        "node": ">=12.11.0"
-      }
-    },
     "node_modules/@primeuix/styled": {
       "version": "0.7.4",
       "license": "MIT",
@@ -3085,34 +2993,12 @@
       }
     },
     "node_modules/@primeuix/styles": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@primeuix/styles/-/styles-3.0.0.tgz",
-      "integrity": "sha512-nFsG2V0kbn3Q/fr0EV0Lxy2cKeW1F+WFXyxWI1CxWAAXW34mTCLkDd6OFbN5dP9hrSJOVaeXWzTdoonh1sdklQ==",
-      "license": "SEE LICENSE IN LICENSE.md",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@primeuix/styles/-/styles-2.0.3.tgz",
+      "integrity": "sha512-2ykAB6BaHzR/6TwF8ShpJTsZrid6cVIEBVlookSdvOdmlWuevGu5vWOScgIwqWwlZcvkFYAGR/SUV3OHCTBMdw==",
+      "license": "MIT",
       "dependencies": {
-        "@primeuix/styled": "^1.0.0"
-      }
-    },
-    "node_modules/@primeuix/styles/node_modules/@primeuix/styled": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@primeuix/styled/-/styled-1.0.0.tgz",
-      "integrity": "sha512-6SXoeQWwKswSqTv1ygaXNfY7otHo6Rb9mxbKJK5WF8adWlZ6CtwmlNfIP+p8cH/zGccsei/5Bu7IetXlMoZGjQ==",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@primeui/license-manager": "^1.0.0",
-        "@primeuix/utils": "^0.8.0"
-      },
-      "engines": {
-        "node": ">=12.11.0"
-      }
-    },
-    "node_modules/@primeuix/styles/node_modules/@primeuix/utils": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@primeuix/utils/-/utils-0.8.0.tgz",
-      "integrity": "sha512-dZSMKU2XJ7W7VDLuFMS/o4k+QYw4SYIpqSNhR/jdasMaaXl8eq0Gt7fTzTwwq7hgfmfOsI6V5xtzUUIvybOJ/w==",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "engines": {
-        "node": ">=12.11.0"
+        "@primeuix/styled": "^0.7.4"
       }
     },
     "node_modules/@primeuix/themes": {
@@ -3130,14 +3016,13 @@
       }
     },
     "node_modules/@primevue/core": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@primevue/core/-/core-5.0.0.tgz",
-      "integrity": "sha512-VGw1a5m3bSHosAQScg7huvD8ZFQ4cfltmbIuOSx7gsMS2NnYno9BCIq7O2L2H3zmB0pBLfcpdawb3EPeg1LIxw==",
-      "license": "SEE LICENSE IN LICENSE.md",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/@primevue/core/-/core-4.5.5.tgz",
+      "integrity": "sha512-JpkXhq1ddc70JdsC3CC4dM+UbeeWuCW/8DpS9dNBfrOk824TLSlRlMEGFyVKqRMn5WPQvYLiy3xXfLQeNdSqhQ==",
+      "license": "MIT",
       "dependencies": {
-        "@primeui/license-manager": "^1.0.0",
-        "@primeuix/styled": "^1.0.0",
-        "@primeuix/utils": "^0.8.0"
+        "@primeuix/styled": "^0.7.4",
+        "@primeuix/utils": "^0.6.2"
       },
       "engines": {
         "node": ">=12.11.0"
@@ -3146,46 +3031,15 @@
         "vue": "^3.5.0"
       }
     },
-    "node_modules/@primevue/core/node_modules/@primeuix/styled": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@primeuix/styled/-/styled-1.0.0.tgz",
-      "integrity": "sha512-6SXoeQWwKswSqTv1ygaXNfY7otHo6Rb9mxbKJK5WF8adWlZ6CtwmlNfIP+p8cH/zGccsei/5Bu7IetXlMoZGjQ==",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@primeui/license-manager": "^1.0.0",
-        "@primeuix/utils": "^0.8.0"
-      },
-      "engines": {
-        "node": ">=12.11.0"
-      }
-    },
-    "node_modules/@primevue/core/node_modules/@primeuix/utils": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@primeuix/utils/-/utils-0.8.0.tgz",
-      "integrity": "sha512-dZSMKU2XJ7W7VDLuFMS/o4k+QYw4SYIpqSNhR/jdasMaaXl8eq0Gt7fTzTwwq7hgfmfOsI6V5xtzUUIvybOJ/w==",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "engines": {
-        "node": ">=12.11.0"
-      }
-    },
     "node_modules/@primevue/icons": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@primevue/icons/-/icons-5.0.0.tgz",
-      "integrity": "sha512-DyrtQhmLRiIkldjm5jmuqiFeNN05n4VWd1sw4+WfJ0Zlb+5T4YASw6CGtCITPzHVYyx6XuuEMifruzc8OVpQrw==",
-      "license": "SEE LICENSE IN LICENSE.md",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/@primevue/icons/-/icons-4.5.5.tgz",
+      "integrity": "sha512-eteOhTdAOXEYE9qW1AOrBBgDxQ2szHJxSkEK1XVdV2TKxGM5FQf03Ovms0VDyZTc16XBIgvwYjXJQS0BPbhPaA==",
+      "license": "MIT",
       "dependencies": {
-        "@primeuix/utils": "^0.8.0",
-        "@primevue/core": "5.0.0"
+        "@primeuix/utils": "^0.6.2",
+        "@primevue/core": "4.5.5"
       },
-      "engines": {
-        "node": ">=12.11.0"
-      }
-    },
-    "node_modules/@primevue/icons/node_modules/@primeuix/utils": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@primeuix/utils/-/utils-0.8.0.tgz",
-      "integrity": "sha512-dZSMKU2XJ7W7VDLuFMS/o4k+QYw4SYIpqSNhR/jdasMaaXl8eq0Gt7fTzTwwq7hgfmfOsI6V5xtzUUIvybOJ/w==",
-      "license": "SEE LICENSE IN LICENSE.md",
       "engines": {
         "node": ">=12.11.0"
       }
@@ -8740,42 +8594,17 @@
       "license": "SEE LICENSE IN LICENSE.md"
     },
     "node_modules/primevue": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/primevue/-/primevue-5.0.0.tgz",
-      "integrity": "sha512-o0MtP6Dxa5QFZuskBWoiLD7aM/V6emqqJJnd+L2nNSfH4PrQsNpqSVPZODSdNJfKXAD9ekjTAJ+QyHycKCmF3Q==",
-      "license": "SEE LICENSE IN LICENSE.md",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/primevue/-/primevue-4.5.5.tgz",
+      "integrity": "sha512-Kv5REIewCdP806QaoU+4nBXfmpzOGFKkZ9qH4KsL6MjiAQVc4PUzypt8erl4r3Vzh3nr3aWZIxkxYRRsLGiX2A==",
+      "license": "MIT",
       "dependencies": {
-        "@primeicons/vue": "^8.0.0",
-        "@primeui/license-manager": "^1.0.0",
-        "@primeuix/motion": "^1.0.0",
-        "@primeuix/styled": "^1.0.0",
-        "@primeuix/styles": "^3.0.0",
-        "@primeuix/utils": "^0.8.0",
-        "@primevue/core": "5.0.0",
-        "@primevue/icons": "5.0.0"
+        "@primeuix/styled": "^0.7.4",
+        "@primeuix/styles": "^2.0.3",
+        "@primeuix/utils": "^0.6.2",
+        "@primevue/core": "4.5.5",
+        "@primevue/icons": "4.5.5"
       },
-      "engines": {
-        "node": ">=12.11.0"
-      }
-    },
-    "node_modules/primevue/node_modules/@primeuix/styled": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@primeuix/styled/-/styled-1.0.0.tgz",
-      "integrity": "sha512-6SXoeQWwKswSqTv1ygaXNfY7otHo6Rb9mxbKJK5WF8adWlZ6CtwmlNfIP+p8cH/zGccsei/5Bu7IetXlMoZGjQ==",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@primeui/license-manager": "^1.0.0",
-        "@primeuix/utils": "^0.8.0"
-      },
-      "engines": {
-        "node": ">=12.11.0"
-      }
-    },
-    "node_modules/primevue/node_modules/@primeuix/utils": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@primeuix/utils/-/utils-0.8.0.tgz",
-      "integrity": "sha512-dZSMKU2XJ7W7VDLuFMS/o4k+QYw4SYIpqSNhR/jdasMaaXl8eq0Gt7fTzTwwq7hgfmfOsI6V5xtzUUIvybOJ/w==",
-      "license": "SEE LICENSE IN LICENSE.md",
       "engines": {
         "node": ">=12.11.0"
       }

--- a/apps/front/package.json
+++ b/apps/front/package.json
@@ -22,7 +22,7 @@
     "pinia": "^4.0.2",
     "primeflex": "^4.0.0",
     "primeicons": "^8.0.0",
-    "primevue": "^5.0.0",
+    "primevue": "^4.5.5",
     "vue": "^3.5.40",
     "vue-router": "^5.2.0"
   },


### PR DESCRIPTION
## 概要

Dependabot PR #326 で `primevue 4.5.5 → 5.0.0` に自動バンプされた結果、アプリ上に「Invalid PrimeUI License」の警告が表示される問題を修正。

## 原因

PrimeVue v5.0.0 では商用ライセンスが必要になったため、未設定の場合にライセンス警告が表示される。

## 変更内容

- `primevue`: `^5.0.0` → `^4.5.5`
- `@primevue/themes`: `^4.5.4` のまま（v5系は存在しないため）