### PR TITLE
fix: 特典を探すタブの現在地周辺ボタンを削除

### DIFF
--- a/apps/front/src/components/organisms/AppSearchBenefit.vue
+++ b/apps/front/src/components/organisms/AppSearchBenefit.vue
@@ -50,15 +50,6 @@
         <AppButton :label="'クリア'" :primary="false" :icon="'pi pi-trash'" @click="clearConditions" />
         <AppButton type="submit" :label="'検索'" :primary="true" :icon="'pi pi-search'" :disabled="isLoading" />
       </div>
-      <!-- 現在地周辺フィルターボタン -->
-      <div class="form-btn mt-2">
-        <AppButton
-          label="現在地周辺"
-          severity="secondary"
-          icon="pi pi-map-marker"
-          @click="filterByCurrentLocation"
-        />
-      </div>
     </form>
   </div>
 


### PR DESCRIPTION
## Summary
- 特典を探すタブに存在した「現在地周辺」ボタンを削除
- ボタンのクリックハンドラ `filterByCurrentLocation` が未実装のまま残存していたため除去
- 距離スライダーによる現在地周辺フィルター機能は引き続き動作

## Test plan
- [ ] 特典を探すタブを開き、「現在地周辺」ボタンが表示されないことを確認
- [ ] 距離スライダーが正常に動作し、現在地周辺フィルターが機能することを確認
- [ ] 検索・クリアボタンが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)