### PR TITLE
fix: 情報を報告ボタンを右側に配置

### DIFF
--- a/apps/front/src/components/atoms/AppButton.vue
+++ b/apps/front/src/components/atoms/AppButton.vue
@@ -33,7 +33,7 @@ const props = withDefaults(defineProps<{
 });
 
 const emit = defineEmits<{
-  (e: 'click'): void;
+  (e: 'click', event: MouseEvent): void;
 }>();
 
 const modelValue = computed(() => {
@@ -45,8 +45,8 @@ const classes = computed(() => ({
   "p-app-button-primary": props.primary,
 }));
 
-const onClick = () => {
-  emit('click');
+const onClick = (event: MouseEvent) => {
+  emit('click', event);
 };
 </script>
 

--- a/apps/front/src/components/organisms/AppSearchBenefit.vue
+++ b/apps/front/src/components/organisms/AppSearchBenefit.vue
@@ -131,12 +131,14 @@
                     最終確認日: {{ formatLastConfirmedDate(benefit.lastConfirmedDate) }}
                   </div>
                   <!-- 情報報告ボタン -->
-                  <AppButton
-                    label="情報を報告"
-                    :primary="false"
-                    size="small"
-                    @click.stop="openReportDialog(benefit)"
-                  />
+                  <div class="report-btn">
+                    <AppButton
+                      label="情報を報告"
+                      :primary="false"
+                      size="small"
+                      @click.stop="openReportDialog(benefit)"
+                    />
+                  </div>
                 </AppCard>
               </template>
             </div>
@@ -184,11 +186,14 @@
               最終確認日: {{ formatLastConfirmedDate(benefit.lastConfirmedDate) }}
             </div>
             <!-- 情報報告ボタン -->
-            <AppButton
-              label="情報を報告"
-              :primary="false"
-              @click.stop="openReportDialog(benefit)"
-            />
+            <div class="report-btn">
+              <AppButton
+                label="情報を報告"
+                :primary="false"
+                size="small"
+                @click.stop="openReportDialog(benefit)"
+              />
+            </div>
           </AppCard>
         </template>
       </template>
@@ -584,6 +589,12 @@ onMounted(() => {
 .radius-value {
   font-weight: normal;
   color: base.$text-secondary;
+}
+
+.report-btn {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 8px;
 }
 
 .last-confirmed {


### PR DESCRIPTION
## 概要

特典カード内の「情報を報告」ボタンを右側に配置しました。

## 変更内容

- `AppSearchBenefit.vue`: 「情報を報告」ボタンを `.report-btn` ラッパーで囲み、`display: flex; justify-content: flex-end` で右揃えに変更（アコーディオン表示・フラット表示の両方）
- `AppSearchBenefit.vue`: フラット表示側のボタンに `size="small"` を追加してサイズを統一
- `AppButton.vue`: クリックイベントに `MouseEvent` を渡すよう修正（事前に行われていた変更を含む）

## テスト手順

- [ ] 特典検索を実行し、カード内の「情報を報告」ボタンが右端に表示されることを確認
- [ ] カテゴリ未指定（アコーディオン表示）・カテゴリ指定済み（フラット表示）の両方で確認
- [ ] ボタンクリックで報告ダイアログが正常に開くことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)