### PR TITLE
docs: 技術スタックとテーブル定義を最新化

### DIFF
--- a/docs/01_overview/tech_stack.md
+++ b/docs/01_overview/tech_stack.md
@@ -66,7 +66,7 @@ graph TB
 | Vue Router | 5.x | SPAルーティング |
 | Pinia | 4.x | 状態管理 |
 | Axios | 1.x | HTTP通信クライアント |
-| PrimeVue | 5.x | UIコンポーネントライブラリ |
+| PrimeVue | 4.5.5 | UIコンポーネントライブラリ |
 | MapLibre GL JS | 5.x | 地図表示 |
 | ESLint + Prettier | - | コード品質管理 |
 | Jest | 30.x | ユニットテスト |

--- a/docs/03_database/table_definitions.md
+++ b/docs/03_database/table_definitions.md
@@ -71,6 +71,7 @@
 | ADDRESS | VARCHAR(200) | | | | 住所 |
 | LATITUDE | NUMERIC(10,7) | | | | 緯度 |
 | LONGITUDE | NUMERIC(10,7) | | | | 経度 |
+| LAST_CONFIRMED_DATE | DATE | | | | 情報確認日 |
 | SYS_CREATED_AT | TIMESTAMP | | | | 作成日時 |
 | SYS_UPDATED_AT | TIMESTAMP | | | | 更新日時 |
 


### PR DESCRIPTION
## 概要

実装と乖離していたドキュメントを最新化しました。

## 変更内容

- `docs/01_overview/tech_stack.md`: PrimeVue バージョンを `5.x` → `4.5.5` に修正（#340 のダウングレードを反映）
- `docs/03_database/table_definitions.md`: BENEFIT テーブルに `LAST_CONFIRMED_DATE DATE` カラムを追記（#342 の実装を反映）

## 確認方法

- [ ] tech_stack.md の PrimeVue バージョンが `4.5.5` になっていること
- [ ] table_definitions.md の BENEFIT テーブルに `LAST_CONFIRMED_DATE` カラムが記載されていること