### PR TITLE
fix: 特典検索の現在地周辺フィルタリングのパフォーマンス改善

### DIFF
--- a/apps/back/src/main/java/io/github/taichi0373/kumamoto_henno_map/repository/dao/BenefitDetailDao.java
+++ b/apps/back/src/main/java/io/github/taichi0373/kumamoto_henno_map/repository/dao/BenefitDetailDao.java
@@ -1,5 +1,6 @@
 package io.github.taichi0373.kumamoto_henno_map.repository.dao;
 
+import java.math.BigDecimal;
 import java.util.List;
 
 import org.seasar.doma.Dao;
@@ -77,17 +78,27 @@ public interface BenefitDetailDao {
     }
 
     /**
-     * 利用資格条件で検索（年齢・運転免許所持状況・自治体コード・キーワード・カテゴリコード）
+     * 利用資格条件で検索（年齢・運転免許所持状況・自治体コード・キーワード・カテゴリコード・バウンディングボックス）
+     * <p>
+     * 現在地周辺フィルタリング時は minLat/maxLat/minLng/maxLng を指定することで、
+     * DB側でバウンディングボックスによる事前絞り込みを行い、転送データ量を削減する。
+     * Haversine精度フィルタリングはサービス層で別途実施する。
+     * </p>
      * @param age            年齢
      * @param licenseStatus  運転免許所持状況
      * @param municipalityCd 対象自治体コード
      * @param keyword        フリーワード（特典名・特典内容の部分一致）
      * @param categoryCd     カテゴリコード
+     * @param minLat         緯度の下限（nullの場合は絞り込まない）
+     * @param maxLat         緯度の上限（nullの場合は絞り込まない）
+     * @param minLng         経度の下限（nullの場合は絞り込まない）
+     * @param maxLng         経度の上限（nullの場合は絞り込まない）
      * @return 特典詳細一覧
      */
     default List<BenefitDetailEntity> selectEligible(
             Integer age, String licenseStatus, String municipalityCd,
-            String keyword, String categoryCd) {
+            String keyword, String categoryCd,
+            BigDecimal minLat, BigDecimal maxLat, BigDecimal minLng, BigDecimal maxLng) {
         QueryDsl queryDsl = new QueryDsl(Config.get(this));
         BenefitDetailEntity_ e = new BenefitDetailEntity_();
 
@@ -125,6 +136,15 @@ public interface BenefitDetailDao {
                     // カテゴリコードで絞り込み
                     if (!ValidateUtils.isNullOrEmpty(categoryCd)) {
                         c.eq(e.categoryCd, categoryCd);
+                    }
+                    // バウンディングボックスによる事前絞り込み（現在地周辺フィルタリング時のみ）
+                    if (minLat != null) {
+                        c.isNotNull(e.latitude);
+                        c.isNotNull(e.longitude);
+                        c.ge(e.latitude, minLat);
+                        c.le(e.latitude, maxLat);
+                        c.ge(e.longitude, minLng);
+                        c.le(e.longitude, maxLng);
                     }
                 })
                 .fetch();

--- a/apps/back/src/main/java/io/github/taichi0373/kumamoto_henno_map/service/BenefitService.java
+++ b/apps/back/src/main/java/io/github/taichi0373/kumamoto_henno_map/service/BenefitService.java
@@ -1,5 +1,6 @@
 package io.github.taichi0373.kumamoto_henno_map.service;
 
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.Optional;
 
@@ -55,23 +56,41 @@ public class BenefitService {
      * 検索条件に一致する特典を検索
      */
     public List<BenefitDetailEntity> searchBenefits(BenefitEligibilityDto request) {
-        // 特典適用条件に一致する特典を取得
+        // 現在地周辺フィルタリング時はDB側でバウンディングボックスによる事前絞り込みを行う
+        BigDecimal minLat = null, maxLat = null, minLng = null, maxLng = null;
+        double radiusKm = 2.0;
+        if (request.getLatitude() != null && request.getLongitude() != null) {
+            radiusKm = (request.getRadiusKm() != null) ? request.getRadiusKm() : 2.0;
+            double lat = request.getLatitude();
+            double lng = request.getLongitude();
+            // 緯度方向: 1度 ≈ 111km
+            double latDelta = radiusKm / 111.0;
+            // 経度方向: 1度 ≈ 111km * cos(緯度)
+            double lngDelta = radiusKm / (111.0 * Math.cos(Math.toRadians(lat)));
+            minLat = BigDecimal.valueOf(lat - latDelta);
+            maxLat = BigDecimal.valueOf(lat + latDelta);
+            minLng = BigDecimal.valueOf(lng - lngDelta);
+            maxLng = BigDecimal.valueOf(lng + lngDelta);
+        }
+
+        // 特典適用条件に一致する特典を取得（現在地指定時はバウンディングボックスでDB側絞り込み）
         List<BenefitDetailEntity> results = benefitDetailDao.selectEligible(
             request.getAge(),
             request.getLicenseStatus(),
             request.getMunicipalityCd(),
             request.getKeyword(),
-            request.getCategoryCd()
+            request.getCategoryCd(),
+            minLat, maxLat, minLng, maxLng
         );
 
-        // 現在地周辺フィルタリング
+        // 現在地周辺フィルタリング（Haversine公式で正確な距離判定）
         if (request.getLatitude() != null && request.getLongitude() != null) {
-            double radiusKm = (request.getRadiusKm() != null) ? request.getRadiusKm() : 2.0;
+            final double finalRadiusKm = radiusKm;
             results = results.stream()
                 .filter(b -> b.getLatitude() != null && b.getLongitude() != null)
                 .filter(b -> isWithinRadius(
                     b.getLatitude().doubleValue(), b.getLongitude().doubleValue(),
-                    request.getLatitude(), request.getLongitude(), radiusKm))
+                    request.getLatitude(), request.getLongitude(), finalRadiusKm))
                 .collect(java.util.stream.Collectors.toList());
         }
 

--- a/apps/back/src/test/java/io/github/taichi0373/kumamoto_henno_map/service/BenefitServiceNearbyTest.java
+++ b/apps/back/src/test/java/io/github/taichi0373/kumamoto_henno_map/service/BenefitServiceNearbyTest.java
@@ -50,7 +50,7 @@ class BenefitServiceNearbyTest {
     void 現在地指定なしのとき全件返す() {
         BenefitDetailEntity b1 = createBenefitWithCoords("B001", KUMAMOTO_LAT, KUMAMOTO_LNG);
         BenefitDetailEntity b2 = createBenefitWithCoords("B002", 33.0, 131.0); // 遠い
-        when(benefitDetailDao.selectEligible(any(), any(), any(), any(), any()))
+        when(benefitDetailDao.selectEligible(any(), any(), any(), any(), any(), any(), any(), any(), any()))
             .thenReturn(List.of(b1, b2));
 
         BenefitEligibilityDto request = new BenefitEligibilityDto();
@@ -67,7 +67,7 @@ class BenefitServiceNearbyTest {
         BenefitDetailEntity nearby = createBenefitWithCoords("B001", 32.7930, 130.7416);
         // 熊本市役所から約30km
         BenefitDetailEntity far = createBenefitWithCoords("B002", 33.0, 131.0);
-        when(benefitDetailDao.selectEligible(any(), any(), any(), any(), any()))
+        when(benefitDetailDao.selectEligible(any(), any(), any(), any(), any(), any(), any(), any(), any()))
             .thenReturn(List.of(nearby, far));
 
         BenefitEligibilityDto request = new BenefitEligibilityDto();
@@ -86,7 +86,7 @@ class BenefitServiceNearbyTest {
         BenefitDetailEntity noCoords = new BenefitDetailEntity();
         noCoords.setBenefitId("B003");
         // latitude, longitude = null
-        when(benefitDetailDao.selectEligible(any(), any(), any(), any(), any()))
+        when(benefitDetailDao.selectEligible(any(), any(), any(), any(), any(), any(), any(), any(), any()))
             .thenReturn(List.of(noCoords));
 
         BenefitEligibilityDto request = new BenefitEligibilityDto();


### PR DESCRIPTION
## 概要

closes #348

現在地からの距離を指定して検索した際、結果が返ってくるまでに時間がかかる問題を修正。

## 原因

`BenefitService.searchBenefits()` が距離フィルタリング時にDB全件取得後、JavaのStreamでHaversine計算を全件実行していた。特典件数が多い場合、全レコードをJavaヒープに展開してから計算するため遅くなっていた。

## 修正内容

- `BenefitDetailDao.selectEligible()` に緯度経度のバウンディングボックスパラメータ（minLat/maxLat/minLng/maxLng）を追加し、SQL側で矩形絞り込みを実施
- `BenefitService.searchBenefits()` で現在地・半径からバウンディングボックスを計算してDAOに渡すよう変更
- Haversine公式による精度フィルタリングはサービス層で引き続き実施（精度は変わらない）
- `BenefitServiceNearbyTest` のモックをパラメータ数変更に合わせて更新

## 動作の変化

| | 修正前 | 修正後 |
|---|---|---|
| DB取得 | 全件 | バウンディングボックス内のみ |
| Java処理 | 全件Haversine計算 | バウンディングボックス内のみHaversine計算 |
| 精度 | Haversine | Haversine（変わらず） |

## テスト

- `BenefitServiceNearbyTest` 全3ケース通過確認済み
- バックエンド全テスト通過確認済み