### PR TITLE
fix: AdminInitializerが既存管理者ユーザーのパスワードを更新するように修正

### DIFF
--- a/apps/back/src/main/java/io/github/taichi0373/kumamoto_henno_map/runner/AdminInitializer.java
+++ b/apps/back/src/main/java/io/github/taichi0373/kumamoto_henno_map/runner/AdminInitializer.java
@@ -17,7 +17,8 @@ import io.github.taichi0373.kumamoto_henno_map.repository.entity.UsersEntity;
  * アプリ起動時に管理者ユーザーを初期化するランナー。
  * <p>
  * プロパティ {@code admin.username} / {@code admin.password} / {@code admin.email} が
- * すべて設定されており、かつ同名ユーザーが存在しない場合のみ管理者ユーザーを作成する。
+ * すべて設定されている場合に動作する。同名ユーザーが存在しない場合は新規作成し、
+ * 存在する場合はパスワード・メール・管理者フラグを環境変数の値で更新する。
  * </p>
  */
 @Component
@@ -53,8 +54,14 @@ public class AdminInitializer implements CommandLineRunner {
             return;
         }
 
-        if (usersDao.selectByUsername(username) != null) {
-            log.info("管理者初期化スキップ: ユーザー '{}' は既に存在します", username);
+        UsersEntity existing = usersDao.selectByUsername(username);
+        if (existing != null) {
+            existing.setPasswordHash(passwordEncoder.encode(password));
+            existing.setEmail(email);
+            existing.setIsAdmin("1");
+            existing.setSystemField(new SystemField(existing.getSystemField().getSysCreatedAt(), LocalDateTime.now()));
+            usersDao.update(existing);
+            log.info("管理者ユーザー '{}' のパスワードを更新しました", username);
             return;
         }
 


### PR DESCRIPTION
## 概要

- issue #349 の修正

## 原因

`AdminInitializer` はアプリ起動時に環境変数（`ADMIN_USERNAME` / `ADMIN_PASSWORD` / `ADMIN_EMAIL`）から管理者ユーザーを初期化するが、同名ユーザーが既に存在する場合はスキップしていた。

本番環境では `USERS.SQL` のシードデータにより `admin:admin` がDBに登録済みのため、`ADMIN_USERNAME=admin` を設定した場合に既存ユーザーが検出されて処理がスキップされ、環境変数のパスワードが一切反映されなかった。

## 修正内容

- 同名ユーザーが存在する場合、スキップではなく `update` でパスワード・メール・管理者フラグを環境変数の値で上書きするように変更

## テスト計画

- [ ] 本番環境で `ADMIN_USERNAME=admin` / `ADMIN_PASSWORD=<新しいパスワード>` を設定してアプリを再起動し、新しいパスワードでログインできることを確認
- [ ] ログに「管理者ユーザー 'admin' のパスワードを更新しました」が出力されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)